### PR TITLE
add description field to MetricCollector

### DIFF
--- a/pytheus/metrics.py
+++ b/pytheus/metrics.py
@@ -32,6 +32,7 @@ class MetricCollector:
     def __init__(
         self,
         name: str,
+        description: str,
         metric_class: type['Metric'],
         required_labels: Sequence[str] | None = None,
     ) -> None:
@@ -42,6 +43,7 @@ class MetricCollector:
             self._validate_labels(required_labels)
 
         self.name = name
+        self.description = description
         self._required_labels = set(required_labels) if required_labels else None
         self._metric = metric_class(self)
         self._labeled_metrics: dict[tuple[str, ...], Metric] = {}
@@ -135,7 +137,6 @@ class Metric:
         return f'{self.__class__.__qualname__}({self._collector.name})'
 
 
-# TODO: count exception raised
 class Counter(Metric):
 
     def __init__(
@@ -188,13 +189,13 @@ class Counter(Metric):
 
 
 # this could be a class method, but might want to avoid it
-def create_metric(name: str, required_labels: Sequence[str] | None = None) -> Metric:
-    collector = MetricCollector(name, Metric, required_labels)
+def create_metric(name: str, description: str, required_labels: Sequence[str] | None = None) -> Metric:
+    collector = MetricCollector(name, description, Metric, required_labels)
     return Metric(collector)
 
 
-def create_counter(name: str, required_labels: Sequence[str] | None = None) -> Metric:
-    collector = MetricCollector(name, Counter, required_labels)
+def create_counter(name: str, description: str, required_labels: Sequence[str] | None = None) -> Metric:
+    collector = MetricCollector(name, description, Counter, required_labels)
     return Counter(collector)
 
 
@@ -203,7 +204,3 @@ def create_counter(name: str, required_labels: Sequence[str] | None = None) -> M
 class Label:
     name: str
     value: str
-
-
-# m = MetricCollector('name', ['bbo'])
-my_metric = create_metric('name', ['bbo'])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,7 +18,7 @@ class TestMetricCollector:
         ],
     )
     def test_name_with_correct_values(self, name):
-        MetricCollector(name, Metric)
+        MetricCollector(name, 'desc', Metric)
 
     @pytest.mark.parametrize(
         'name',
@@ -31,11 +31,11 @@ class TestMetricCollector:
     )
     def test_name_with_incorrect_values(self, name):
         with pytest.raises(ValueError):
-            MetricCollector(name, Metric)
+            MetricCollector(name, 'desc', Metric)
 
     def test_validate_label_with_correct_values(self):
         labels = ['action', 'method', '_type']
-        collector = MetricCollector('name', Metric)
+        collector = MetricCollector('name', 'desc', Metric)
         collector._validate_labels(labels)
 
     @pytest.mark.parametrize(
@@ -47,17 +47,17 @@ class TestMetricCollector:
         ],
     )
     def test_validate_label_with_incorrect_values(self, label):
-        collector = MetricCollector('name', Metric)
+        collector = MetricCollector('name', 'desc', Metric)
         with pytest.raises(ValueError):
             collector._validate_labels([label])
 
     def test_collect_without_labels(self):
-        counter = create_counter('name')
+        counter = create_counter('name', 'desc')
         samples = counter._collector.collect()
         assert len(samples) == 1
 
     def test_collect_with_labels(self):
-        counter = create_counter('name', required_labels=['a', 'b'])
+        counter = create_counter('name', 'desc', required_labels=['a', 'b'])
         counter_a = counter.labels({'a': '1', 'b': '2'})
         counter_b = counter.labels({'a': '7', 'b': '8'})
         counter_c = counter.labels({'a': '6'})  # this should not be creating a sample
@@ -69,7 +69,7 @@ class TestCounter:
 
     @pytest.fixture
     def counter(self):
-        return create_counter('name')
+        return create_counter('name', 'desc')
 
     def test_can_increment(self, counter):
         counter.inc()


### PR DESCRIPTION
This adds the description/help field required by prometheus to aid in explaining a metrics purpose.

It is expected to be a `str` but there is no enforcing of that right now, either `None` values should be transformed into `str` if the user forces them or just ignore them and when exposing transform them directly from the registry 🤔 