### PR TITLE
Initinal registry implementation

### DIFF
--- a/pytheus/metrics.py
+++ b/pytheus/metrics.py
@@ -6,6 +6,7 @@ from typing import Sequence, Iterator
 
 from pytheus.backends import LockedValue
 from pytheus.exceptions import UnobservableMetricException
+from pytheus.registry import REGISTRY_PROXY, Registry
 
 
 Labels = dict[str, str]
@@ -35,6 +36,7 @@ class MetricCollector:
         description: str,
         metric_class: type['Metric'],
         required_labels: Sequence[str] | None = None,
+        registry: Registry = REGISTRY_PROXY
     ) -> None:
         if metric_name_re.fullmatch(name) is None:
             raise ValueError(f'Invalid metric name: {name}')
@@ -47,6 +49,7 @@ class MetricCollector:
         self._required_labels = set(required_labels) if required_labels else None
         self._metric = metric_class(self)
         self._labeled_metrics: dict[tuple[str, ...], Metric] = {}
+        registry.register(self)
 
         # this will register to the collector
 
@@ -111,23 +114,18 @@ class Metric:
         if not _labels or self._collector._required_labels is None:
             return self
 
-        add_to_collector: bool = True
-
         # TODO: add labels validation
         if len(_labels) != len(self._collector._required_labels):
-            add_to_collector = False
+            # does not add to collector
+            return self.__class__(self._collector, _labels)
 
+        # add to collector
         sorted_label_values = tuple(v for _, v in sorted(_labels.items()))
-        # get or add to collector
-        if add_to_collector:
-            if sorted_label_values in self._collector._labeled_metrics:
-                metric = self._collector._labeled_metrics[sorted_label_values]
-            else:
-                metric = self.__class__(self._collector, _labels)
-                self._collector._labeled_metrics[sorted_label_values] = metric
+        if sorted_label_values in self._collector._labeled_metrics:
+            metric = self._collector._labeled_metrics[sorted_label_values]
         else:
             metric = self.__class__(self._collector, _labels)
-
+            self._collector._labeled_metrics[sorted_label_values] = metric
         return metric
 
     def collect(self) -> Sample:

--- a/pytheus/registry.py
+++ b/pytheus/registry.py
@@ -1,5 +1,9 @@
+from logging import getLogger
 from threading import Lock
 from typing import Iterable, Protocol
+
+
+logger = getLogger(__name__)
 
 
 class Collector(Protocol):
@@ -23,18 +27,20 @@ class Registry(Protocol):
 class CollectorRegistry:
     def __init__(self, prefix: str = None) -> None:
         self._lock = Lock()
-        self._prefix = prefix
+        self.prefix = prefix
         self._collectors: dict[str, Collector] = {}
 
     def register(self, collector: Collector) -> None:
         with self._lock:
             if collector.name in self._collectors:
+                logger.warning(f"collector with name '{collector.name}' already registred")
                 return
             self._collectors[collector.name] = collector
 
     def unregister(self, collector: Collector) -> None:
         with self._lock:
             if collector.name not in self._collectors:
+                logger.warning(f"no collector found with name '{collector.name}'")
                 return
             del self._collectors[collector.name]
 

--- a/pytheus/registry.py
+++ b/pytheus/registry.py
@@ -1,0 +1,63 @@
+from threading import Lock
+from typing import Iterable, Protocol
+
+
+class Collector(Protocol):
+    name: str
+
+    def collect(self) -> Iterable:
+        pass
+
+
+class Registry(Protocol):
+    def register(self, collector: Collector):
+        pass
+
+    def unregister(self, collector: Collector):
+        pass
+
+    def collect(self) -> Iterable:
+        pass
+
+
+class CollectorRegistry:
+    def __init__(self, prefix: str = None) -> None:
+        self._lock = Lock()
+        self._prefix = prefix
+        self._collectors: dict[str, Collector] = {}
+
+    def register(self, collector: Collector) -> None:
+        with self._lock:
+            if collector.name in self._collectors:
+                return
+            self._collectors[collector.name] = collector
+
+    def unregister(self, collector: Collector) -> None:
+        with self._lock:
+            if collector.name not in self._collectors:
+                return
+            del self._collectors[collector.name]
+
+    def collect(self) -> Iterable:
+        for collector in self._collectors.values():
+            yield from collector.collect()
+
+
+class CollectorRegistryProxy:
+    def __init__(self, registry: Registry = None) -> None:
+        self._registry = registry or CollectorRegistry()
+
+    def set_registry(self, registry: Registry) -> None:
+        self._registry = registry
+
+    def register(self, collector: Collector) -> None:
+        self._registry.register(collector)
+
+    def unregister(self, collector: Collector) -> None:
+        self._registry.unregister(collector)
+
+    def collect(self) -> Iterable:
+        return self._registry.collect()
+
+
+REGISTRY_PROXY = CollectorRegistryProxy()


### PR DESCRIPTION
This contains the protocals and the initial implementation of the registry and registryproxy. Yet it's not very clear how it will play along with the current approach. From the prometheus client requirement, any metric should be able to register with a default registry. But in the current implementation registry interact with `MetricsController` which is responsible of managing the underlying metrics. Now new metrics required a MetricsContreller instance.