### PR TITLE
Add mmap dictionary class

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+          architecture: x64
+      - run: make setup
+      - run: make lint
+      - run: make pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 __pycache__
+.coverage
 .pyc
 venv
 *.egg-info
 dist
+build
 .python-version
 .pytest_cache
 .mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: setup flake8 mypy lint pytest pytest-log test
+
+SRC := pytheus/
+TEST := tests/
+
+PYTEST := pytest --cov pytheus --cov-report term --cov-report html -v $(TEST)
+
+setup:
+	pip install .[redis,test]
+	mypy --install-types --non-interactive $(SRC) $(TEST)
+
+flake8:
+	flake8 $(SRC) $(TEST)
+
+mypy:
+	mypy $(SRC) $(TEST)
+
+lint: flake8 mypy
+
+pytest:
+	$(PYTEST)
+
+pytest-log:
+	$(PYTEST) -o log_cli=true -o log_cli_level=INFO
+
+test: lint pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = [
   { name="Llandy Riveron Del Risco", email="llandy3d@gmail.com" },
 ]
-description = "playing with metrics"
+description = "Prometheus Python client with extensibility and multiprocess capabilities"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
@@ -16,7 +16,11 @@ repository = "https://github.com/Llandy3d/pytheus"
 
 [project.optional-dependencies]
 test = [
-  "pytest >= 7.0.0",
+  "flake8 == 5.0.4",
+  "ipython == 8.4.0",
+  "mypy == 0.971",
+  "pytest == 7.1.2",
+  "pytest-cov == 3.0.0"
 ]
 
 redis = [

--- a/pytheus/metrics.py
+++ b/pytheus/metrics.py
@@ -90,7 +90,6 @@ class Metric:
         self._collector = collector
         self._labels = labels
         self._can_observe = self._check_can_observe()
-        self._metric_value_backend = None
 
         if self._can_observe:
             self._metric_value_backend = get_backend(self)
@@ -164,7 +163,7 @@ class Counter(Metric):
     @contextmanager
     def count_exceptions(
         self,
-        exceptions: type[Exception] | tuple[Exception] | None = None
+        exceptions: type[Exception] | tuple[type[Exception]] | None = None
     ) -> Generator[None, None, None]:
         """
         Will count and reraise raised exceptions.
@@ -189,12 +188,16 @@ class Counter(Metric):
 
 
 # this could be a class method, but might want to avoid it
-def create_metric(name: str, description: str, required_labels: Sequence[str] | None = None) -> Metric:
+def create_metric(
+    name: str, description: str, required_labels: Sequence[str] | None = None
+) -> Metric:
     collector = _MetricCollector(name, description, Metric, required_labels)
     return Metric(collector)
 
 
-def create_counter(name: str, description: str, required_labels: Sequence[str] | None = None) -> Counter:
+def create_counter(
+    name: str, description: str, required_labels: Sequence[str] | None = None
+) -> Counter:
     collector = _MetricCollector(name, description, Counter, required_labels)
     return Counter(collector)
 

--- a/pytheus/mmap.py
+++ b/pytheus/mmap.py
@@ -1,0 +1,377 @@
+import abc
+import collections
+import mmap
+import os
+import struct
+import typing
+
+# See https://docs.python.org/3/library/struct.html#format-characters
+StructFormatString = typing.Literal["i", "d", "?", "s"]
+StructFormatType = typing.Union[int, float, bool, str]
+
+STRUCT_INT_FORMAT: StructFormatString = "i"
+STRUCT_FLOAT_FORMAT: StructFormatString = "d"
+STRUCT_BOOL_FORMAT: StructFormatString = "?"
+STRUCT_STR_FORMAT: StructFormatString = "s"
+
+BYTE_ALIGNMENT = 4
+
+DEFAULT_BACKEND = "DEFAULT_BACKEND"
+
+
+class MmapDictTypeBackend(abc.ABC):
+    def __init__(self, mmap: mmap.mmap) -> None:
+        self._mmap = mmap
+
+    def move_right_and_pad(self, position: int, count: int):
+        """ Move a section of the array to the right and pad zeros in the gap """
+        self._mmap[position:] = b"\0" * count + self._mmap[position:-count]
+
+    def move_left_and_pad(self, position: int, count: int):
+        """ Move a section of the array to the left and pad zeros at the end """
+        self._mmap[position:] = self._mmap[position+count:] + b"\0" * count
+
+    @abc.abstractmethod
+    def get_(self, position: int) -> StructFormatType:
+        ...
+
+    @abc.abstractmethod
+    def set_(self, position: int, value: StructFormatType) -> None:
+        ...
+
+    @abc.abstractmethod
+    def size_by_value(self, value: StructFormatType) -> int:
+        ...
+
+    @abc.abstractmethod
+    def size_by_position(self, position: int) -> int:
+        ...
+
+
+class FixedSizeMmapDictTypeBackend(MmapDictTypeBackend):
+    def __init__(
+        self, mmap: mmap.mmap,
+        struct_format_str: StructFormatString,
+        size: int,
+    ) -> None:
+        super().__init__(mmap)
+        self._struct_format_str = struct_format_str
+        self._size = size
+        self._padding = b""
+        remainder = self._size % BYTE_ALIGNMENT
+        if self._size < BYTE_ALIGNMENT:
+            self._aligned_size = BYTE_ALIGNMENT
+            if remainder != 0:
+                self._padding = b"\0" * (BYTE_ALIGNMENT - remainder)
+        else:
+            self._aligned_size = self._size
+            if remainder != 0:
+                self._aligned_size += BYTE_ALIGNMENT
+                self._padding = b"\0" * (BYTE_ALIGNMENT - remainder)
+
+    def get_(self, position: int) -> StructFormatType:
+        return struct.unpack(self._struct_format_str, self._mmap[position:position+self._size])[0]
+
+    def set_(self, position: int, value: StructFormatType) -> None:
+        self._mmap[position:position+self._aligned_size] = \
+            struct.pack(self._struct_format_str, value) + self._padding
+
+    def size_by_value(self, value: StructFormatType) -> int:
+        return self._aligned_size
+
+    def size_by_position(self, position: int) -> int:
+        return self._aligned_size
+
+
+class StrMmapDictTypeBackend(MmapDictTypeBackend):
+    def __init__(
+        self, mmap: mmap.mmap,
+        encoding: str,
+    ) -> None:
+        super().__init__(mmap)
+        self._encoding = encoding
+
+    def get_(self, position: int) -> str:
+        offset_position = position + 4
+        buffer = self._mmap[offset_position:offset_position+self._text_size_by_position(position)]
+        return buffer.decode(self._encoding)
+
+    def set_(self, position: int, value: str) -> None:  # type: ignore[override]
+        size = self._text_size_by_value(value)
+        padding = b""
+        remainder = size % BYTE_ALIGNMENT
+        if remainder != 0:
+            padding = b"\0" * (BYTE_ALIGNMENT - remainder)
+        offset_position = position + 4
+        self._mmap[position:offset_position] = struct.pack(STRUCT_INT_FORMAT, size)
+        self._mmap[offset_position:offset_position+size+len(padding)] = \
+            value.encode(self._encoding) + padding
+
+    def size_by_value(self, value: str) -> int:  # type: ignore
+        return self._total_size(self._text_size_by_value(value))
+
+    def size_by_position(self, position: int) -> int:
+        return self._total_size(self._text_size_by_position(position))
+
+    def _total_size(self, text_size: int) -> int:
+        combined_size = 4 + text_size
+        if combined_size < BYTE_ALIGNMENT:
+            return BYTE_ALIGNMENT
+        else:
+            remainder = combined_size % BYTE_ALIGNMENT
+            if remainder:
+                return combined_size + BYTE_ALIGNMENT - remainder
+            else:
+                return combined_size
+
+    def _text_size_by_position(self, position: int) -> int:
+        return struct.unpack(STRUCT_INT_FORMAT, self._mmap[position:position+4])[0]
+
+    def _text_size_by_value(self, value: str) -> int:
+        return len(value.encode(self._encoding))
+
+
+class MmapDict(collections.abc.MutableMapping):
+    """ Python dictionary that streams its data to a memory-mapped file.
+
+    ############
+    # Features #
+    ############
+
+    - It only support basic types: int, float, bool and string.
+
+    - It is not thread-safe for writing, which means only a single process should be writing.
+
+    - Index access will work in these two cases:
+
+        - In the write process, provided there is only one.
+
+        - In any read-only process, provided there is no write process running at the same time.
+
+    - Index cache is built in these two ways:
+
+        - As part of the initial write process as keys get inserted.
+
+        - If you open the file later on in a separate process for reading or further writing, the
+          cache can be rebuilt with self.initialize_cache() or by just iterating through the keys.
+
+    ######################
+    # How data is stored #
+    ######################
+
+    - First 4 bytes have an integer with the position of the next new entry that would be inserted.
+
+    - Next 4 bytes have an integer with the number of entries stored so far.
+
+    - Each new key/value pair gets appended to the file sequentially after it, and we keep an
+      internal in-memory index cache of what position each key is located, to enable index access.
+
+    - Each type is stored in the following way:
+
+        - Integers(4 bytes) and doubles(8 bytes) use that fixed amount of space.
+
+        - Booleans(1 byte) add padding to fill the 4 byte alignment.
+
+        - Strings(x bytes) use 4 initial bytes that hold an integer with the size of the string,
+          then we store the string itself and add padding to fill the 4 byte alignment.
+    """
+    # Control integer positions
+    NEXT_WRITE_POSITION_CONTROL_INT = 0
+    LENGTH_CONTROL_INT = 4
+
+    def __init__(
+        self,
+        file_path: str,
+        value_format_string: StructFormatString,
+        key_format_string: StructFormatString = "s",
+        block_size: int = 1 << 20,  # 1 Megabyte
+        encoding: str = "utf-8",
+    ) -> None:
+        super().__init__()
+        self._file_path = file_path
+        self._value_format_string: StructFormatString = value_format_string
+        self._key_format_string: StructFormatString = key_format_string
+        self._block_size = block_size
+        self._encoding = encoding
+        # Initialize file descriptors, type backends and control bytes
+        file_exists = os.path.exists(file_path) and os.path.isfile(file_path)
+        if not file_exists:
+            with open(file_path, mode="w+b") as file_handler:
+                file_handler.truncate(block_size)
+            self._set_file_descriptors()
+            self._set_type_backends()
+            self._next_write_position = 8
+            self._length = 0
+        else:
+            self._set_file_descriptors()
+            self._set_type_backends()
+        self._total_size = os.stat(file_path).st_size
+        # Initialize cache
+        self.index: collections.OrderedDict[StructFormatType, int] = collections.OrderedDict()
+
+    def __getitem__(self, key: StructFormatType) -> StructFormatType:
+        key_position = self._get_index_position(key)
+        return self._type_backends[self._value_format_string].get_(
+            key_position + self._get_key_size_by_value(key)
+        )
+
+    def __setitem__(self, key: StructFormatType, value: StructFormatType) -> None:
+
+        def _extend_file_if_needed(required_new_size: int):
+            while True:
+                if self._total_size < self._next_write_position + required_new_size:
+                    self._extend_file()
+                else:
+                    break
+
+        value_offset = self._get_value_size_by_value(value)
+
+        try:
+            key_position = self._get_index_position(key)
+            key_offset = self._get_key_size_by_position(key_position)
+            value_position = key_position + key_offset
+            total_offset = key_offset + value_offset
+            old_value_offset = self._get_value_size_by_value(self[key])
+            required_new_size = value_offset - old_value_offset
+            _extend_file_if_needed(required_new_size)
+            if required_new_size < 0:
+                self._type_backends[DEFAULT_BACKEND].move_left_and_pad(
+                    position=value_position+old_value_offset,
+                    count=-required_new_size,
+                )
+                self._move_index_keys(key, required_new_size)
+            elif required_new_size > 0:
+                self._type_backends[DEFAULT_BACKEND].move_right_and_pad(
+                    position=value_position+old_value_offset,
+                    count=required_new_size
+                )
+                self._move_index_keys(key, required_new_size)
+        except KeyError:
+            key_position = self._next_write_position
+            key_offset = self._get_key_size_by_value(key)
+            value_position = key_position + key_offset
+            total_offset = key_offset + value_offset
+            required_new_size = total_offset
+            _extend_file_if_needed(required_new_size)
+            self._length += 1
+            self.index[key] = key_position
+        self._type_backends[self._key_format_string].set_(key_position, key)
+        self._type_backends[self._value_format_string].set_(value_position, value)
+        self._next_write_position += required_new_size
+
+    def __delitem__(self, key: StructFormatType) -> None:
+        key_position = self._get_index_position(key)
+        key_offset = self._get_key_size_by_position(key_position)
+        value_position = key_position + key_offset
+        total_offset = key_offset + self._get_value_size_by_position(value_position)
+        self._type_backends[DEFAULT_BACKEND].move_left_and_pad(key_position, total_offset)
+        self._next_write_position -= total_offset
+        self._length -= 1
+        self._move_index_keys(key, -total_offset)
+        del self.index[key]
+
+    def __iter__(self) -> typing.Iterable[StructFormatType]:  # type: ignore
+        key_cursor = 8  # After the two control bytes
+        for _ in range(len(self)):  # Iterate all keys and build the cache
+            key = self._type_backends[self._key_format_string].get_(key_cursor)
+            key_offset = self._get_key_size_by_position(key_cursor)
+            self.index[key] = key_cursor
+            key_cursor += key_offset + self._get_value_size_by_position(key_cursor + key_offset)
+            yield key
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __enter__(self) -> "MmapDict":
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        self.close()
+
+    def _set_file_descriptors(self) -> None:
+        self._file = open(self._file_path, mode="r+b")
+        self._mmap = mmap.mmap(self._file.fileno(), 0)
+
+    def _set_type_backends(self) -> None:
+        self._type_backends: dict[str, MmapDictTypeBackend] = {
+            STRUCT_INT_FORMAT: FixedSizeMmapDictTypeBackend(self._mmap, STRUCT_INT_FORMAT, 4),
+            STRUCT_FLOAT_FORMAT: FixedSizeMmapDictTypeBackend(self._mmap, STRUCT_FLOAT_FORMAT, 8),
+            STRUCT_BOOL_FORMAT: FixedSizeMmapDictTypeBackend(self._mmap, STRUCT_BOOL_FORMAT, 1),
+            STRUCT_STR_FORMAT: StrMmapDictTypeBackend(self._mmap, self._encoding),
+        }
+        self._type_backends[DEFAULT_BACKEND] = self._type_backends[STRUCT_INT_FORMAT]
+
+    def _extend_file(self) -> None:
+        self.close()
+        with open(self._file_path, mode="a+b") as file_handler:
+            file_handler.write(b"\0" * self._block_size)
+        self._total_size += self._block_size
+        self._set_file_descriptors()
+        self._set_type_backends()
+
+    def _get_index_position(self, key: StructFormatType) -> int:
+        if key not in self.index:
+            raise KeyError(
+                f"Key '{key}' is missing. It could also be that some other process is writing to "
+                "the file and the cache is not being properly updated, which is not supported."
+            )
+        return self.index[key]
+
+    def _move_index_keys(self, after_key: StructFormatType, diff: int):
+        key_found = False
+        for cached_index, cached_key in enumerate(self.index):
+            if after_key == cached_key:
+                key_found = True
+                continue
+            if key_found:
+                self.index[cached_key] += diff
+
+    def _get_key_size_by_value(self, key: StructFormatType) -> int:
+        return self._type_backends[self._key_format_string].size_by_value(key)
+
+    def _get_key_size_by_position(self, position: int) -> int:
+        return self._type_backends[self._key_format_string].size_by_position(position)
+
+    def _get_value_size_by_value(self, value: StructFormatType) -> int:
+        return self._type_backends[self._value_format_string].size_by_value(value)
+
+    def _get_value_size_by_position(self, position: int) -> int:
+        return self._type_backends[self._value_format_string].size_by_position(position)
+
+    @property
+    def _next_write_position(self) -> int:
+        return self._type_backends[STRUCT_INT_FORMAT].get_(self.NEXT_WRITE_POSITION_CONTROL_INT)  # type: ignore # noqa: E501
+
+    @_next_write_position.setter
+    def _next_write_position(self, position: int) -> None:
+        self._type_backends[STRUCT_INT_FORMAT].set_(self.NEXT_WRITE_POSITION_CONTROL_INT, position)
+
+    @property
+    def _length(self) -> int:
+        return self._type_backends[STRUCT_INT_FORMAT].get_(self.LENGTH_CONTROL_INT)  # type: ignore
+
+    @_length.setter
+    def _length(self, length: int) -> None:
+        self._type_backends[STRUCT_INT_FORMAT].set_(self.LENGTH_CONTROL_INT, length)
+
+    @property
+    def total_size(self) -> int:
+        return self._total_size
+
+    @property
+    def used_size(self) -> int:
+        return self._next_write_position
+
+    @property
+    def is_index_usable(self) -> bool:
+        return len(self.index) == len(self)
+
+    def initialize_cache(self) -> None:
+        for _ in iter(self):
+            pass
+
+    def close(self) -> None:
+        if self._mmap:
+            self._mmap.close()
+        if self._file:
+            self._file.close()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -58,9 +58,9 @@ class TestMetricCollector:
 
     def test_collect_with_labels(self):
         counter = create_counter('name', 'desc', required_labels=['a', 'b'])
-        counter_a = counter.labels({'a': '1', 'b': '2'})
-        counter_b = counter.labels({'a': '7', 'b': '8'})
-        counter_c = counter.labels({'a': '6'})  # this should not be creating a sample
+        counter.labels({'a': '1', 'b': '2'})
+        counter.labels({'a': '7', 'b': '8'})
+        counter.labels({'a': '6'})  # this should not be creating a sample
         samples = counter._collector.collect()
         assert len(list(samples)) == 2
 

--- a/tests/test_mmap.py
+++ b/tests/test_mmap.py
@@ -1,0 +1,213 @@
+import mmap
+import os
+import tempfile
+import struct
+
+import pytest
+
+from pytheus.mmap import (
+    FixedSizeMmapDictTypeBackend,
+    StrMmapDictTypeBackend,
+    STRUCT_INT_FORMAT,
+    STRUCT_FLOAT_FORMAT,
+    STRUCT_BOOL_FORMAT,
+    MmapDict,
+)
+
+
+@pytest.fixture
+def mmap_handle():
+    try:
+        tmp_file_handle_ = tempfile.NamedTemporaryFile(mode="w+b")
+        tmp_file_handle_.truncate(1 << 10)  # 1 Kilobyte
+        file_handle_ = open(tmp_file_handle_.name, mode="r+b")
+        mmap_handle_ = mmap.mmap(file_handle_.fileno(), 0)
+        yield mmap_handle_
+    finally:
+        mmap_handle_.close()
+        file_handle_.close()
+        tmp_file_handle_.close()
+
+
+def test_mmap_dict_type_backend_base(mmap_handle):
+    type_backend = FixedSizeMmapDictTypeBackend(
+        mmap=mmap_handle,
+        struct_format_str=STRUCT_INT_FORMAT,
+        size=4,
+    )
+    mmap_handle[2:14] = b"Hello world!"
+    assert mmap_handle[2:14] == b"Hello world!"
+    assert len(mmap_handle) == 1 << 10
+    type_backend.move_left_and_pad(4, 6)
+    assert mmap_handle[2:14] == b"Herld!\x00\x00\x00\x00\x00\x00"
+    assert len(mmap_handle) == 1 << 10
+    type_backend.move_right_and_pad(5, 4)
+    assert mmap_handle[2:14] == b"Her\x00\x00\x00\x00ld!\x00\x00"
+    assert len(mmap_handle) == 1 << 10
+
+
+def test_int_mmap_dict_type_backend(mmap_handle):
+    type_backend = FixedSizeMmapDictTypeBackend(
+        mmap=mmap_handle,
+        struct_format_str=STRUCT_INT_FORMAT,
+        size=4,
+    )
+    type_backend.set_(0, 22)
+    assert type_backend.get_(0) == 22
+    assert mmap_handle[0:4] == b"\x16\x00\x00\x00"
+    assert type_backend.size_by_value(22) == 4
+    assert type_backend.size_by_position(0) == 4
+
+
+def test_float_mmap_dict_type_backend(mmap_handle):
+    type_backend = FixedSizeMmapDictTypeBackend(
+        mmap=mmap_handle,
+        struct_format_str=STRUCT_FLOAT_FORMAT,
+        size=8,
+    )
+    type_backend.set_(0, 22.0)
+    assert type_backend.get_(0) == 22.0
+    assert mmap_handle[0:8] == b"\x00\x00\x00\x00\x00\x006@"
+    assert type_backend.size_by_value(22.0) == 8
+    assert type_backend.size_by_position(0) == 8
+
+
+def test_bool_mmap_dict_type_backend(mmap_handle):
+    type_backend = FixedSizeMmapDictTypeBackend(
+        mmap=mmap_handle,
+        struct_format_str=STRUCT_BOOL_FORMAT,
+        size=1,
+    )
+    type_backend.set_(0, True)
+    assert type_backend.get_(0) is True
+    assert mmap_handle[0:4] == b"\x01\x00\x00\x00"
+    assert type_backend.size_by_value(True) == 4
+    assert type_backend.size_by_position(0) == 4
+
+
+@pytest.mark.parametrize(
+    "expected_size,text",
+    [
+        (4, ""),
+        (8, "He!"),
+        (8, "Hey!"),
+        (12, "Hello!"),
+        (16, "Hello you!"),
+        (16, "Hello world!"),
+    ],
+)
+def test_str_mmap_dict_type_backend(mmap_handle, expected_size, text):
+    type_backend = StrMmapDictTypeBackend(
+        mmap=mmap_handle,
+        encoding="utf-8",
+    )
+    type_backend.set_(0, text)
+    assert type_backend.get_(0) == text
+    encoded_text = text.encode("utf-8")
+    encoded_text_length = len(encoded_text)
+    assert mmap_handle[0:expected_size] == \
+        struct.pack("i", encoded_text_length) + \
+        encoded_text + \
+        b"\0" * (expected_size - encoded_text_length - 4)
+    assert type_backend.size_by_value(text) == expected_size
+    assert type_backend.size_by_position(0) == expected_size
+
+
+def test_mmap_dict_core():
+    path_1 = "test1.mmap"
+    path_2 = "test2.mmap"
+    mmap_dict_kwargs = dict(
+        file_path=path_1,
+        key_format_string="s",
+        value_format_string="d",
+        block_size=1 << 6,  # 64 bytes
+        encoding="utf-8",
+    )
+    m_1 = MmapDict(**mmap_dict_kwargs)
+    try:
+        # 1. Check initial state
+        assert len(m_1) == 0
+        assert m_1.total_size == 64
+        assert m_1.used_size == 8  # 2 * 4 control ints
+        assert m_1.is_index_usable
+        assert m_1.index == {}
+        # 2. Add a couple of entries
+        m_1["key_1"] = 1.0
+        m_1["key_2"] = 2.0
+        assert len(m_1) == 2
+        assert m_1.total_size == 64
+        assert m_1.used_size == 48  # 2 * 4 control ints + 2 * 12 keys + 2 * 8 doubles
+        assert m_1.is_index_usable
+        assert m_1.index == {"key_1": 8, "key_2": 28}
+        assert m_1["key_1"] == 1.0
+        assert m_1["key_2"] == 2.0
+        # 3. Writing an existing entry does not increase the size
+        m_1["key_1"] = 3.0
+        assert len(m_1) == 2
+        assert m_1.total_size == 64
+        assert m_1.used_size == 48  # 2 * 4 control ints + 2 * 12 keys + 2 * 8 doubles
+        assert m_1.is_index_usable
+        assert m_1.index == {"key_1": 8, "key_2": 28}
+        assert m_1["key_1"] == 3.0
+        assert m_1["key_2"] == 2.0
+        # 4. Adding another key forces a new block
+        m_1["key_3"] = 3.0
+        assert len(m_1) == 3
+        assert m_1.total_size == 128
+        assert m_1.used_size == 68  # 2 * 4 control ints + 3 * 12 keys + 3 * 8 doubles
+        assert m_1.is_index_usable
+        assert m_1.index == {"key_1": 8, "key_2": 28, "key_3": 48}
+        assert m_1["key_1"] == 3.0
+        assert m_1["key_2"] == 2.0
+        assert m_1["key_3"] == 3.0
+        # 5. Delete an entry
+        del m_1["key_2"]
+        assert len(m_1) == 2
+        assert m_1.total_size == 128
+        assert m_1.used_size == 48  # 2 * 4 control ints + 2 * 12 keys + 2 * 8 doubles
+        assert m_1.is_index_usable
+        assert m_1.index == {"key_1": 8, "key_3": 28}
+        assert m_1["key_1"] == 3.0
+        assert m_1["key_3"] == 3.0
+        # 6. Re-open file as context manager and rebuild cache
+        with MmapDict(**mmap_dict_kwargs) as m_2:
+            m_2.initialize_cache()
+            assert len(m_2) == 2
+            assert m_2.total_size == 128
+            assert m_2.used_size == 48  # 2 * 4 control ints + 2 * 12 keys + 2 * 8 doubles
+            assert m_2.is_index_usable
+            assert m_2.index == {"key_1": 8, "key_3": 28}
+            assert m_2["key_1"] == 3.0
+            assert m_2["key_3"] == 3.0
+        # 7. Create a third dict on a different file path to test str overwrite values
+        with MmapDict(**dict(mmap_dict_kwargs, file_path=path_2, value_format_string="s")) as m_3:
+            m_3["key_1"] = "Hello "
+            m_3["key_2"] = "world!"
+            assert len(m_3) == 2
+            assert m_3.total_size == 64
+            assert m_3.used_size == 56  # 2 * 4 control ints + 2 * 12 key + 2 * 12 value
+            assert m_3.is_index_usable
+            assert m_3.index == {"key_1": 8, "key_2": 32}
+            assert m_3["key_1"] == "Hello "
+            assert m_3["key_2"] == "world!"
+            m_3["key_2"] = "you!"
+            assert len(m_3) == 2
+            assert m_3.total_size == 64
+            assert m_3.used_size == 52  # 2 * 4 control ints + 2 * 12 key + 1 * 12 + 1 * 8 value
+            assert m_3.is_index_usable
+            assert m_3.index == {"key_1": 8, "key_2": 32}
+            assert m_3["key_1"] == "Hello "
+            assert m_3["key_2"] == "you!"
+            m_3["key_2"] = "dear person!"
+            assert len(m_3) == 2
+            assert m_3.total_size == 64
+            assert m_3.used_size == 60  # 2 * 4 control ints + 2 * 12 key + 1 * 12 + 1 * 16 value
+            assert m_3.is_index_usable
+            assert m_3.index == {"key_1": 8, "key_2": 32}
+            assert m_3["key_1"] == "Hello "
+            assert m_3["key_2"] == "dear person!"
+    finally:
+        m_1.close()
+        os.remove(path_1)
+        if os.path.exists(path_2):
+            os.remove(path_2)

--- a/tests/test_mmap_performance.py
+++ b/tests/test_mmap_performance.py
@@ -1,0 +1,137 @@
+import functools
+import json
+import logging
+import os
+import pickle
+import random
+import string
+import threading
+import time
+import typing
+
+from pytheus.mmap import MmapDict
+
+LOGGER = logging.getLogger(__name__)
+
+WRITE_ITERATIONS = 5000
+READ_ITERATIONS = 100
+
+
+def test_indexed_writes():
+
+    # 1. Generate samples
+
+    samples = {}
+    for _ in range(WRITE_ITERATIONS):
+        count = random.randint(1, 50)
+        samples["".join(random.sample(string.ascii_letters, count))] = random.uniform(0.0, 10.0)
+
+    # 2. Assert speed
+
+    time_results = {}
+
+    def _timing(f):
+        @functools.wraps(f)
+        def wrap(*args, **kw):
+            start = time.time()
+            result = f(*args, **kw)
+            elapsed_time = time.time()-start
+            time_results[f.__name__] = elapsed_time
+            LOGGER.info(f"Function {f.__name__} took {elapsed_time:.4f} seconds")
+            return result
+        return wrap
+
+    def _launch_threads(*functions: typing.Callable):
+        threads = [threading.Thread(target=f) for f in functions]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    mmap_file_path = "test.mmap"
+    json_file_path = "test.json"
+    pickle_file_path = "test.pickle"
+    mmap_dict_kwargs = dict(
+        file_path=mmap_file_path,
+        key_format_string="s",
+        value_format_string="d",
+        block_size=1 << 20,
+        encoding="utf-8",
+    )
+
+    def _remove_files_if_present():
+        for file_path in [mmap_file_path, json_file_path, pickle_file_path]:
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    _remove_files_if_present()
+
+    mmap_dict_write = MmapDict(**mmap_dict_kwargs)
+    json_dict = {}
+    json_write_file_handle = open(json_file_path, "w")
+    pickle_dict = {}
+    pickle_write_file_handle = open(pickle_file_path, "wb")
+
+    @_timing
+    def _mmap_random_write():
+        for key, value in samples.items():
+            mmap_dict_write[key] = value
+
+    @_timing
+    def _json_random_write():
+        for key, value in samples.items():
+            json_dict[key] = value
+            json_write_file_handle.write(json.dumps(json_dict, separators=(",", ":")))
+            json_write_file_handle.seek(0)
+
+    @_timing
+    def _pickle_random_write():
+        for key, value in samples.items():
+            pickle_dict[key] = value
+            pickle.dump(pickle_dict, pickle_write_file_handle, pickle.HIGHEST_PROTOCOL)
+            pickle_write_file_handle.seek(0)
+
+    _launch_threads(_mmap_random_write, _json_random_write, _pickle_random_write)
+
+    # 3. Log file size
+
+    mmap_file_size = os.stat(mmap_file_path).st_size
+    json_file_size = os.stat(json_file_path).st_size
+    pickle_file_size = os.stat(pickle_file_path).st_size
+    LOGGER.info(f"{WRITE_ITERATIONS} write iterations, mmap file size => {mmap_file_size}")
+    LOGGER.info(f"{WRITE_ITERATIONS} write iterations, json file size => {json_file_size}")
+    LOGGER.info(f"{WRITE_ITERATIONS} write iterations, pickle file size => {pickle_file_size}")
+
+    # 4. Assert speed when reading all keys
+
+    @_timing
+    def _mmap_random_read():
+        with MmapDict(**mmap_dict_kwargs) as mmap_dict_read:
+            for _ in range(READ_ITERATIONS):
+                data = {key: value for key, value in mmap_dict_read.items()}
+                assert data == samples
+
+    @_timing
+    def _json_random_read():
+        with open(json_file_path) as f:
+            for _ in range(READ_ITERATIONS):
+                data = json.loads(f.read())
+                assert data == samples
+                f.seek(0)
+
+    @_timing
+    def _pickle_random_read():
+        with open(pickle_file_path, "rb") as f:
+            for _ in range(READ_ITERATIONS):
+                data = pickle.loads(f.read())
+                assert data == samples
+                f.seek(0)
+
+    _launch_threads(_mmap_random_read, _json_random_read, _pickle_random_read)
+
+    # 5. Cleanup
+
+    mmap_dict_write.close()
+    json_write_file_handle.close()
+    pickle_write_file_handle.close()
+    _remove_files_if_present()


### PR DESCRIPTION
- I added a small `Makefile` and a pipeline, as I found myself linting and testing regularly
- This new `mmap.py` module would enable the multiprocess mode using files
- Some other minor fixes to flake8 and mypy

Performance results compared to other naive approaches like using `json` or `pickle` are interesting:
x 100 faster writes, which is the most important thing, as we write metrics constantly
x 4 slower reads, which might not be as problematic as you only need to read every scrape time

Still want to make this a bit more performant to match the current client, which gets similar write numbers, but better read ones.