### PR TITLE
Backends protocol based rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,6 @@ print(counter._metric_value_backend.config)
 
 ## Create your own Backend
 
-### WIP
-
 ### Custom Backend
 
 You can create your own backend by implementing a class that fulfills the `Backend` protocol.

--- a/README.md
+++ b/README.md
@@ -363,9 +363,34 @@ print(counter._metric_value_backend.config)
 
 You can create your own backend by implementing a class that fulfills the `Backend` protocol.
 
+```python
+class Backend(Protocol):
+    def __init__(
+        # optional config ?
+        self,
+        config: BackendConfig,
+        metric: "_Metric",
+        histogram_bucket: str | None = None,
+    ) -> None:
+        ...
+
+    def inc(self, value: float) -> None:
+        ...
+
+    def dec(self, value: float) -> None:
+        ...
+
+    def set(self, value: float) -> None:
+        ...
+
+    def get(self) -> float:
+        ...
+```
+
 ### Initialization hook
 
 It's possible that you want to initialize your custom backed or there are one time steps that you want to happen on import.
+
 To achieve that you can use the class method hook called `_initialize` that accepts a `BackendConfig` parameter.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -354,3 +354,22 @@ print(counter._metric_value_backend.__class__)
 print(counter._metric_value_backend.config)
 # {'host': '127.0.0.1', 'port': 6379}
 ```
+
+## Create your own Backend
+
+### WIP
+
+### Custom Backend
+
+You can create your own backend by implementing a class that fulfills the `Backend` protocol.
+
+### Initialization hook
+
+It's possible that you want to initialize your custom backed or there are one time steps that you want to happen on import.
+To achieve that you can use the class method hook called `_initialize` that accepts a `BackendConfig` parameter.
+
+```python
+@classmethod
+def _initialize(cls, config: "BackendConfig") -> None:
+    # initialization steps
+```

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ print(counter._metric_value_backend.config)
 You can define environment configuration to have different defaults, using two environment variables:
 
 ```bash
-export PYTHEUS_BACKEND_CLASS="pytheus.backends.MultipleProcessFileBackend"
+export PYTHEUS_BACKEND_CLASS="pytheus.backends.MultiProcessFileBackend"
 export PYTHEUS_BACKEND_CONFIG="./config.json"
 ```
 
@@ -319,7 +319,7 @@ counter = Counter(
     required_labels=["label_a", "label_b"],
 )
 print(counter._metric_value_backend.__class__)
-# <class 'pytheus.backends.MultipleProcessFileBackend'>
+# <class 'pytheus.backends.MultiProcessFileBackend'>
 print(counter._metric_value_backend.config)
 # {'pytheus_file_directory': "./"}
 ```
@@ -330,10 +330,10 @@ setup we have just described:
 ```python
 
 from pytheus.metrics import Counter
-from pytheus.backends import MultipleProcessRedisBackend, load_backend
+from pytheus.backends import MultiProcessRedisBackend, load_backend
 
 load_backend(
-    backend_class=MultipleProcessRedisBackend,
+    backend_class=MultiProcessRedisBackend,
     backend_config={
       "host": "127.0.0.1",
       "port":  6379
@@ -350,7 +350,7 @@ counter = Counter(
     required_labels=["label_a", "label_b"],
 )
 print(counter._metric_value_backend.__class__)
-# <class 'pytheus.backends.MultipleProcessRedisBackend'>
+# <class 'pytheus.backends.MultiProcessRedisBackend'>
 print(counter._metric_value_backend.config)
 # {'host': '127.0.0.1', 'port': 6379}
 ```

--- a/example.py
+++ b/example.py
@@ -3,12 +3,12 @@ import time
 from flask import Flask
 
 from pytheus.backends import load_backend
-from pytheus.backends.redis import MultipleProcessRedisBackend
+from pytheus.backends.redis import MultiProcessRedisBackend
 from pytheus.exposition import generate_metrics
 from pytheus.metrics import Histogram
 
 load_backend(
-    backend_class=MultipleProcessRedisBackend,
+    backend_class=MultiProcessRedisBackend,
     backend_config={"host": "127.0.0.1", "port": 6379},
 )
 

--- a/pytheus/backends/base.py
+++ b/pytheus/backends/base.py
@@ -93,6 +93,9 @@ def load_backend(
     else:
         BACKEND_CONFIG = {}  # Default
 
+    if hasattr(BACKEND_CLASS, "_initialize"):
+        BACKEND_CLASS._initialize(BACKEND_CONFIG)
+
 
 def get_backend(metric: "_Metric", histogram_bucket: str | None = None) -> Backend:
     # Probably ok not to cache this and allow each metric to keep its own

--- a/pytheus/backends/base.py
+++ b/pytheus/backends/base.py
@@ -93,6 +93,7 @@ def load_backend(
     else:
         BACKEND_CONFIG = {}  # Default
 
+    # initialization hook
     if hasattr(BACKEND_CLASS, "_initialize"):
         BACKEND_CLASS._initialize(BACKEND_CONFIG)
 

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 EXPIRE_KEY_TIME = 3600  # 1 hour
 
 
-class MultipleProcessRedisBackend:
+class MultiProcessRedisBackend:
     """
     Provides a multi-process backend that uses Redis.
     Single dimension metrics will be stored as list (ex. Counter) while labelled

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -47,11 +47,13 @@ class MultipleProcessRedisBackend:
         elif metric._labels:
             self._labels_hash = "-".join(sorted(metric._labels.values()))
 
-        if self.CONNECTION_POOL is None:
-            MultipleProcessRedisBackend.CONNECTION_POOL = redis.Redis(
-                **config,
-                decode_responses=True,
-            )
+    @classmethod
+    def _initialize(cls, config: "BackendConfig") -> None:
+        cls.CONNECTION_POOL = redis.Redis(
+            **config,
+            decode_responses=True,
+        )
+        cls.CONNECTION_POOL.ping()
 
     def inc(self, value: float) -> None:
         assert self.CONNECTION_POOL is not None

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -2,16 +2,15 @@ from typing import TYPE_CHECKING
 
 import redis
 
-from pytheus.backends.base import Backend, BackendConfig
-
 if TYPE_CHECKING:
+    from pytheus.backends.base import BackendConfig
     from pytheus.metrics import _Metric
 
 
 EXPIRE_KEY_TIME = 3600  # 1 hour
 
 
-class MultipleProcessRedisBackend(Backend):
+class MultipleProcessRedisBackend:
     """
     Provides a multi-process backend that uses Redis.
     Single dimension metrics will be stored as list (ex. Counter) while labelled
@@ -24,12 +23,11 @@ class MultipleProcessRedisBackend(Backend):
 
     def __init__(
         self,
-        config: BackendConfig,
+        config: "BackendConfig",
         metric: "_Metric",
         histogram_bucket: str | None = None,
     ) -> None:
-        super().__init__(config, metric)
-        self._key_name = self.metric._collector.name
+        self._key_name = metric._collector.name
         self._labels_hash = None
         self._histogram_bucket = histogram_bucket
 
@@ -39,24 +37,21 @@ class MultipleProcessRedisBackend(Backend):
 
         # default labels
         joint_labels = None
-        if self.metric._collector._default_labels_count:
-            joint_labels = self.metric._collector._default_labels.copy()  # type: ignore
-            if self.metric._labels:
-                joint_labels.update(self.metric._labels)
+        if metric._collector._default_labels_count:
+            joint_labels = metric._collector._default_labels.copy()  # type: ignore
+            if metric._labels:
+                joint_labels.update(metric._labels)
 
         if joint_labels:
             self._labels_hash = "-".join(sorted(joint_labels.values()))
-        elif self.metric._labels:
-            self._labels_hash = "-".join(sorted(self.metric._labels.values()))
+        elif metric._labels:
+            self._labels_hash = "-".join(sorted(metric._labels.values()))
 
         if self.CONNECTION_POOL is None:
             MultipleProcessRedisBackend.CONNECTION_POOL = redis.Redis(
                 **config,
                 decode_responses=True,
             )
-
-    def is_valid_config(self, config: BackendConfig) -> bool:
-        return True  # TODO
 
     def inc(self, value: float) -> None:
         assert self.CONNECTION_POOL is not None

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -1,0 +1,63 @@
+import os
+from unittest import mock
+
+from pytheus.backends import base
+from pytheus.backends.base import SingleProcessBackend, load_backend
+
+
+class DummyProcessBackend:
+    def __init__(self, config, metric, histogram_bucket=None):
+        pass
+
+    @classmethod
+    def _initialize(cls, config):
+        pass
+
+    def inc(self, value):
+        pass
+
+    def dec(self, value):
+        pass
+
+    def set(self, value):
+        pass
+
+    def get(self):
+        pass
+
+
+class TestLoadBackend:
+    @mock.patch("pytheus.backends.base.BACKEND_CLASS", None)
+    def test_call_without_args(self):
+        load_backend()
+
+        assert base.BACKEND_CLASS is SingleProcessBackend
+        assert base.BACKEND_CONFIG == {}
+
+    def test_with_arguments(self):
+        config = {"bob": "bobby"}
+        load_backend(DummyProcessBackend, config)
+
+        assert base.BACKEND_CLASS is DummyProcessBackend
+        assert base.BACKEND_CONFIG == config
+
+    @mock.patch.dict(
+        os.environ, {"PYTHEUS_BACKEND_CLASS": "tests.backends.test_base.DummyProcessBackend"}
+    )
+    def test_with_environment_variables(self, tmp_path):
+        load_backend()
+
+        assert base.BACKEND_CLASS.__name__ == DummyProcessBackend.__name__
+
+    @mock.patch.dict(
+        os.environ, {"PYTHEUS_BACKEND_CLASS": "tests.backends.test_base.DummyProcessBackend"}
+    )
+    def test_argument_has_priority_over_environment_variable(self):
+        load_backend(SingleProcessBackend)
+
+        assert base.BACKEND_CLASS is SingleProcessBackend
+
+    @mock.patch.object(DummyProcessBackend, "_initialize")
+    def test_initialization_hook(self, _initialize_mock):
+        load_backend(DummyProcessBackend)
+        _initialize_mock.assert_called()

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -100,3 +100,30 @@ def test_get_backend():
     backend_class = get_backend(metric)
 
     assert isinstance(backend_class, SingleProcessBackend)
+
+
+class TestSingleProcessBackend:
+    @pytest.fixture
+    def single_process_backend(self):
+        metric = _Metric("name", "desc", registry=None)
+        return SingleProcessBackend({}, metric)
+
+    def test_creation(self, single_process_backend):
+        assert single_process_backend._value == 0.0
+        assert single_process_backend._lock
+
+    def test_inc(self, single_process_backend):
+        single_process_backend.inc(1)
+        assert single_process_backend._value == 1.0
+
+    def test_dec(self, single_process_backend):
+        single_process_backend.dec(1)
+        assert single_process_backend._value == -1.0
+
+    def test_set(self, single_process_backend):
+        single_process_backend.set(2)
+        assert single_process_backend._value == 2.0
+
+    def test_get(self, single_process_backend):
+        single_process_backend.inc(1)
+        assert single_process_backend.get() == 1.0

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -8,8 +8,10 @@ from pytheus.backends.base import (
     InvalidBackendClassException,
     SingleProcessBackend,
     _import_backend_class,
+    get_backend,
     load_backend,
 )
+from pytheus.metrics import _Metric
 
 
 class DummyProcessBackend:
@@ -90,3 +92,11 @@ class TestImportBackendClass:
     def test_class_not_a_backend_subclass_raises(self):
         with pytest.raises(InvalidBackendClassException):
             _import_backend_class("pytheus.metrics._MetricCollector")
+
+
+def test_get_backend():
+    load_backend()
+    metric = _Metric("name", "desc", registry=None)
+    backend_class = get_backend(metric)
+
+    assert isinstance(backend_class, SingleProcessBackend)


### PR DESCRIPTION
Reworked the `Backend` system to be `Protocol` based so that there is no need to import and subclass a base class to implement a new custom backend.

Added the ability to hook an initialization function that will be called when the class is first loaded for one time step operations via `_initialize`.