### PR TITLE
ci caching & speed improvement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
       - uses: pre-commit/action@v3.0.0
       - name: Run Tests
         run: |
-          tox -e py
+          pytest


### PR DESCRIPTION
cache `pip` dependencies & use directly `pytest` instead of `tox`