### PR TITLE
Add `key_prefix` config support to `MultiProcessRedisBackend`

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -85,6 +85,14 @@ The library also includes a redis based implementation of the backend for suppor
 
 This makes use of the `INCRBYFLOAT` & `HINCRBYFLOAT` redis operations that are `ATOMIC` and as redis is single-threaded it means that even if multiple clients try to update the same value we will end up with the correct one.
 
+!!! tip
+
+    When using the `MultiProcessRedisBackend` you will want to have a separate redis server o database specified per service you are monitoring. If you don't there is a risk that a metric with the same name on one service might overwrite one in another service.
+
+    If you plan to share the same redis server for multiple services, you can configure a prefix that will be added to all the stored metrics with the `key_prefix`.
+
+    For example: `{"host": "127.0.0.1", "port": 6379, "key_prefix": "serviceprefix"}`
+
 ---
 
 ## Loading a different Backend

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Escape `help` & `label_values` during exposition
+- MultiProcessRedisBackend:
+    - Add `key_prefix` config to specify stored key name prefix.
 
 ## 0.0.11
 

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -47,13 +47,21 @@ class MultiProcessRedisBackend:
         elif metric._labels:
             self._labels_hash = "-".join(sorted(metric._labels.values()))
 
+        if "key_prefix" in config:
+            self._key_prefix = config["key_prefix"]
+            self._key_name = f"{self._key_prefix}-{self._key_name}"
+
         # initialize the key in redis
         self._init_key()
 
     @classmethod
     def _initialize(cls, config: "BackendConfig") -> None:
+        redis_config = config.copy()
+        if "key_prefix" in redis_config:
+            del redis_config["key_prefix"]
+
         cls.CONNECTION_POOL = redis.Redis(
-            **config,
+            **redis_config,
             decode_responses=True,
         )
         cls.CONNECTION_POOL.ping()


### PR DESCRIPTION
Adds `key_prefix` support to `MultiProcessRedisBackend` allowing the possibility to set a prefix to be used when saving metrics key names in redis.

Ex. 
with a metric `http_requests_total` having the config `{'key_prefix': 'myprefix'}` will store as `myprefix-http_requests_total` in redis.

Fix #32 