### PR TITLE
improved new redis sample generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
+          pip install -e .[test,redis]
       - uses: pre-commit/action@v3.0.0
       - name: Run Tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,14 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ test = [
   "black == 23.3.0",
   "isort == 5.12.0",
   "tox == 4.4.11",
-  "fakeredis == 2.19.0",
 
   # mypy types
   "types-redis == 4.5.4.0",

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -100,7 +100,6 @@ class MultiProcessRedisBackend:
 
     @classmethod
     def _generate_samples(cls, registry: "Registry") -> Dict["Collector", List["Sample"]]:
-        # cls._initialize_pipeline()
         assert cls.CONNECTION_POOL is not None
 
         # collect samples that are not yet stored with the value

--- a/pytheus/backends/redis.py
+++ b/pytheus/backends/redis.py
@@ -1,11 +1,15 @@
+import json
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import redis
 
+from pytheus.metrics import Sample
+from pytheus.utils import MetricType
+
 if TYPE_CHECKING:
     from pytheus.backends.base import BackendConfig
-    from pytheus.metrics import Sample, _Metric
+    from pytheus.metrics import _Metric
     from pytheus.registry import Collector, Registry
 
 
@@ -35,6 +39,14 @@ class MultiProcessRedisBackend:
         self._key_name = metric._collector.name
         self._labels_hash = None
         self._histogram_bucket = histogram_bucket
+        self._sorted_required_labels = (
+            sorted(metric._collector._required_labels)
+            if metric._collector._required_labels
+            else None
+        )
+
+        if not metric._collector._redis_key_name:
+            metric._collector._redis_key_name = self._key_name
 
         # keys for histograms are of type `myhisto:2.5`
         if histogram_bucket:
@@ -48,9 +60,9 @@ class MultiProcessRedisBackend:
                 joint_labels.update(metric._labels)
 
         if joint_labels:
-            self._labels_hash = "-".join(sorted(joint_labels.values()))
+            self._labels_hash = json.dumps(joint_labels)
         elif metric._labels:
-            self._labels_hash = "-".join(sorted(metric._labels.values()))
+            self._labels_hash = json.dumps(metric._labels)
 
         if "key_prefix" in config:
             self._key_prefix = config["key_prefix"]
@@ -78,11 +90,14 @@ class MultiProcessRedisBackend:
         initialize the same key, it will be idempotent.
         """
         assert self.CONNECTION_POOL is not None
-        if not self.CONNECTION_POOL.exists(self._key_name):
-            if self._labels_hash:
-                self.CONNECTION_POOL.hincrbyfloat(self._key_name, self._labels_hash, 0.0)
-            else:
-                self.CONNECTION_POOL.incrbyfloat(self._key_name, 0.0)
+
+        if self._labels_hash and not self.CONNECTION_POOL.hexists(
+            self._key_name, self._labels_hash
+        ):
+            self.CONNECTION_POOL.hincrbyfloat(self._key_name, self._labels_hash, 0.0)
+
+        elif not self._labels_hash and not self.CONNECTION_POOL.exists(self._key_name):
+            self.CONNECTION_POOL.incrbyfloat(self._key_name, 0.0)
 
         self.CONNECTION_POOL.expire(self._key_name, EXPIRE_KEY_TIME)
 
@@ -101,7 +116,7 @@ class MultiProcessRedisBackend:
         return pipeline.execute()
 
     @classmethod
-    def _generate_samples(cls, registry: "Registry") -> Dict["Collector", List["Sample"]]:
+    def _generate_samples_x(cls, registry: "Registry") -> Dict["Collector", List["Sample"]]:
         cls._initialize_pipeline()
 
         # collect samples that are not yet stored with the value
@@ -125,6 +140,154 @@ class MultiProcessRedisBackend:
 
             for sample, value in zip(samples, owned_values):
                 sample.value = value
+        return samples_dict
+
+    @classmethod
+    def _generate_samples(cls, registry: "Registry") -> Dict["Collector", List["Sample"]]:
+        # cls._initialize_pipeline()
+        assert cls.CONNECTION_POOL is not None
+
+        # collect samples that are not yet stored with the value
+        samples_dict = {}
+        pipeline = cls.CONNECTION_POOL.pipeline()
+        for collector in registry.collect():
+            samples_list: List[Sample] = []
+            samples_dict[collector] = samples_list
+
+            key_name = collector._redis_key_name
+            if collector._required_labels:
+                # hash
+                match collector.type_:
+                    case MetricType.COUNTER | MetricType.GAUGE:
+                        pipeline.expire(key_name, EXPIRE_KEY_TIME)
+                        pipeline.hgetall(key_name)
+                    case MetricType.SUMMARY:
+                        for suffix in ("count", "sum"):
+                            key_with_suffix = f"{key_name}:{suffix}"
+                            pipeline.expire(key_with_suffix, EXPIRE_KEY_TIME)
+                            pipeline.hgetall(key_with_suffix)
+                    case MetricType.HISTOGRAM:
+                        for suffix in collector._metric._upper_bounds[:-1] + [
+                            "+Inf",
+                            "count",
+                            "sum",
+                        ]:
+                            key_with_suffix = f"{key_name}:{suffix}"
+                            pipeline.expire(key_with_suffix, EXPIRE_KEY_TIME)
+                            pipeline.hgetall(key_with_suffix)
+            else:
+                # not hash
+                match collector.type_:
+                    case MetricType.COUNTER | MetricType.GAUGE:
+                        pipeline.expire(key_name, EXPIRE_KEY_TIME)
+                        pipeline.get(key_name)
+                    case MetricType.SUMMARY:
+                        for suffix in ("count", "sum"):
+                            key_with_suffix = f"{key_name}:{suffix}"
+                            pipeline.expire(key_with_suffix, EXPIRE_KEY_TIME)
+                            pipeline.get(key_with_suffix)
+                    case MetricType.HISTOGRAM:
+                        for suffix in collector._metric._upper_bounds[:-1] + [
+                            "+Inf",
+                            "count",
+                            "sum",
+                        ]:
+                            key_with_suffix = f"{key_name}:{suffix}"
+                            pipeline.expire(key_with_suffix, EXPIRE_KEY_TIME)
+                            pipeline.get(key_with_suffix)
+
+        pipeline_data = pipeline.execute()
+
+        values = [
+            0 if item is None else item for item in pipeline_data if item not in (True, False)
+        ]
+
+        # build samples
+        for collector, samples_list in samples_dict.items():
+            if collector._required_labels:
+                # hash
+                match collector.type_:
+                    case MetricType.COUNTER | MetricType.GAUGE:
+                        values_dict = values[0]
+                        values = values[1:]
+                        for labels, value in values_dict.items():
+                            samples_list.append(Sample("", json.loads(labels), float(value)))
+                    case MetricType.SUMMARY:
+                        count_dict = values[0]
+                        sum_dict = values[1]
+                        values = values[2:]
+                        for labels, value in count_dict.items():
+                            samples_list.append(Sample("_count", json.loads(labels), float(value)))
+
+                        for labels, value in sum_dict.items():
+                            samples_list.append(Sample("_sum", json.loads(labels), float(value)))
+
+                        # might be able to do something like this for order but is it safe ?
+                        # count_dict = values[0]
+                        # sum_dict = values[1]
+                        # values = values[2:]
+                        # for (labels_count, value_count),(labels_sum, value_sum)  in
+                        # zip(count_dict.items(), sum_dict.items()):
+                        #
+                        #     samples_list.append(
+                        #         Sample("_count", json.loads(labels_count), float(value_count))
+                        #     )
+                        #     samples_list.append(
+                        #        Sample("_sum", json.loads(labels_sum), float(value_sum))
+                        #    )
+                    case MetricType.HISTOGRAM:
+                        index = 0
+                        suffixes = collector._metric._upper_bounds[:-1] + ["+Inf", "count", "sum"]
+                        for suffix in suffixes:
+                            values_dict = values[index]
+                            index += 1
+
+                            if isinstance(suffix, (int, float)) or suffix == "+Inf":
+                                for labels, value in values_dict.items():
+                                    labels = json.loads(labels)
+                                    labels["le"] = str(suffix)
+                                    samples_list.append(Sample("_bucket", labels, float(value)))
+                            elif suffix == "count":
+                                for labels, value in values_dict.items():
+                                    samples_list.append(
+                                        Sample("_count", json.loads(labels), float(value))
+                                    )
+                            elif suffix == "sum":
+                                for labels, value in values_dict.items():
+                                    samples_list.append(
+                                        Sample("_sum", json.loads(labels), float(value))
+                                    )
+
+                        values = values[len(suffixes) :]
+            else:
+                match collector.type_:
+                    case MetricType.COUNTER | MetricType.GAUGE:
+                        value = values[0]
+                        values = values[1:]
+                        samples_list.append(Sample("", None, float(value)))
+                    case MetricType.SUMMARY:
+                        count_value = values[0]
+                        sum_value = values[1]
+                        values = values[2:]
+                        samples_list.append(Sample("_count", None, float(count_value)))
+                        samples_list.append(Sample("_sum", None, float(sum_value)))
+                    case MetricType.HISTOGRAM:
+                        index = 0
+                        suffixes = collector._metric._upper_bounds[:-1] + ["+Inf", "count", "sum"]
+                        for suffix in suffixes:
+                            value = values[index]
+                            index += 1
+
+                            if isinstance(suffix, (int, float)) or suffix == "+Inf":
+                                labels = {"le": str(suffix)}
+                                samples_list.append(Sample("_bucket", labels, float(value)))
+                            elif suffix == "count":
+                                samples_list.append(Sample("_count", None, float(value)))
+                            elif suffix == "sum":
+                                samples_list.append(Sample("_sum", None, float(value)))
+
+                        values = values[len(suffixes) :]
+
         return samples_dict
 
     def inc(self, value: float) -> None:
@@ -155,23 +318,17 @@ class MultiProcessRedisBackend:
         self.CONNECTION_POOL.expire(self._key_name, EXPIRE_KEY_TIME)
 
     def get(self) -> float:
+        """
+        This is not used directly, useful for tests and possibly debugging so leaving it in but
+        it's not used outside of these cases.
+        """
         assert self.CONNECTION_POOL is not None
-        client = self.CONNECTION_POOL
-
-        pipeline = pipeline_var.get()
-        if pipeline:
-            client = pipeline
 
         if self._labels_hash:
-            value = client.hget(self._key_name, self._labels_hash)
+            value = self.CONNECTION_POOL.hget(self._key_name, self._labels_hash)
         else:
-            value = client.get(self._key_name)
+            value = self.CONNECTION_POOL.get(self._key_name)
 
-        client.expire(self._key_name, EXPIRE_KEY_TIME)
+        self.CONNECTION_POOL.expire(self._key_name, EXPIRE_KEY_TIME)
 
-        if pipeline:
-            return 0.0
-
-        # NOTE: get() directly is only used when collecting metrics & in tests so it makes sense
-        # to consider adding a method only for tests
         return float(value) if value else 0.0

--- a/pytheus/metrics.py
+++ b/pytheus/metrics.py
@@ -86,6 +86,7 @@ class _MetricCollector:
         self._metric = metric
         self._labeled_metrics: Dict[Tuple[str, ...], _Metric] = {}
         self._registry = registry
+        self._redis_key_name: Optional[str] = None
 
         if registry:
             registry.register(self)

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor
+from importlib.util import find_spec
 from unittest import mock
 
 import pytest
@@ -8,6 +9,10 @@ from pytheus.backends.redis import MultiProcessRedisBackend
 from pytheus.exposition import generate_metrics
 from pytheus.metrics import Counter, Gauge, Histogram, Sample, Summary
 from pytheus.registry import CollectorRegistry
+
+if not find_spec("redis"):
+    pytest.skip("skipping redis tests as the module was not found", allow_module_level=True)
+
 
 load_backend(MultiProcessRedisBackend)
 pool = MultiProcessRedisBackend.CONNECTION_POOL

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -261,24 +261,6 @@ def test_multiple_metrics_with_same_name_labeled_with_redis_key_name_dont_overla
     assert counter_b.labels({"bob": "cat"})._metric_value_backend.get() == 1
 
 
-@mock.patch("pytheus.backends.redis.pipeline_var")
-def test_initialize_pipeline(pipeline_var_mock):
-    pipeline_var_mock.get.return_value = None
-    MultiProcessRedisBackend._initialize_pipeline()
-    assert pipeline_var_mock.set.called
-    assert pipeline_var_mock.set.call_args[0][0] is not None
-
-
-@mock.patch("pytheus.backends.redis.pipeline_var")
-def test_execute_and_cleanup_pipeline(pipeline_var_mock):
-    pipeline_mock = mock.Mock()
-    pipeline_var_mock.get.return_value = pipeline_mock
-    MultiProcessRedisBackend._execute_and_cleanup_pipeline()
-    assert pipeline_var_mock.set.called
-    assert pipeline_var_mock.set.call_args[0][0] is None
-    assert pipeline_mock.execute.called
-
-
 def test_generate_samples():
     registry = CollectorRegistry()
     counter = Counter("name", "desc", registry=registry)


### PR DESCRIPTION
Reimplemented `_generate_samples` from `MultiProcessRedisBackend`:
- improved performance for generating metrics
- Fix a bug where on multiprocess on some scrapes a metric wouldn't be picked up due to missing local collector child
- removed FakeRedis dependency
- now on labeled metrics, the labels/value combination will be initialized to 0 if it doesn't exists (before only the key would be initialized)