### PR TITLE
Redis Worker Thread PoC

### DIFF
--- a/pytheus/backends/background_redis.py
+++ b/pytheus/backends/background_redis.py
@@ -1,0 +1,288 @@
+import json
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import redis
+
+from pytheus.metrics import Sample
+from pytheus.utils import MetricType
+
+if TYPE_CHECKING:
+    from pytheus.backends.base import BackendConfig
+    from pytheus.metrics import _Metric
+    from pytheus.registry import Collector, Registry
+
+
+class MultiProcessRedisBackend:
+    """
+    Provides a multi-process backend that uses Redis.
+    Single dimension metrics will be stored as list (ex. Counter) while labelled
+    metrics will be stored in an hash.
+    Currently is very naive, and there is a lot of room for improvement.
+    (ex. maybe store all dimensions in the same hash and be smart on retrieving everything...)
+    """
+
+    EXPIRE_KEY_TIME = 3600  # 1 hour
+    CONNECTION_POOL: Optional[redis.Redis] = None
+
+    def __init__(
+        self,
+        config: "BackendConfig",
+        metric: "_Metric",
+        histogram_bucket: Optional[str] = None,
+    ) -> None:
+        self._key_name = metric._collector.name
+        self._labels_hash = None
+        self._histogram_bucket = histogram_bucket
+        self._sorted_required_labels = (
+            sorted(metric._collector._required_labels)
+            if metric._collector._required_labels
+            else None
+        )
+
+        # keys for histograms are of type `myhisto:2.5`
+        if histogram_bucket:
+            self._key_name = f"{self._key_name}:{histogram_bucket}"
+
+        # default labels
+        joint_labels = None
+        if metric._collector._default_labels_count:
+            joint_labels = metric._collector._default_labels.copy()  # type: ignore
+            if metric._labels:
+                joint_labels.update(metric._labels)
+
+        if joint_labels:
+            self._labels_hash = json.dumps(joint_labels)
+        elif metric._labels:
+            self._labels_hash = json.dumps(metric._labels)
+
+        # NOTE: deprecated
+        if "key_prefix" in config:
+            self._key_prefix = config["key_prefix"]
+            self._key_name = f"{self._key_prefix}-{self._key_name}"
+
+        # initialize the key in redis
+        self._init_key()
+
+    @classmethod
+    def _initialize(cls, config: "BackendConfig") -> None:
+        redis_config = config.copy()
+        if "key_prefix" in redis_config:
+            del redis_config["key_prefix"]
+
+        if "expire_key_time" in redis_config:
+            cls.EXPIRE_KEY_TIME = redis_config["expire_key_time"]
+            del redis_config["expire_key_time"]
+
+        cls.CONNECTION_POOL = redis.Redis(
+            **redis_config,
+            decode_responses=True,
+        )
+        cls.CONNECTION_POOL.ping()
+
+    def _init_key(self) -> None:
+        """
+        If the key doesn't exist in redis we initialize it and set the expiry time.
+        `incrbyfloat` & `hincrbyfloat` are used so if for any reason multiple clients try to
+        initialize the same key, it will be idempotent.
+        """
+        assert self.CONNECTION_POOL is not None
+
+        if self._labels_hash and not self.CONNECTION_POOL.hexists(
+            self._key_name, self._labels_hash
+        ):
+            self.CONNECTION_POOL.hincrbyfloat(self._key_name, self._labels_hash, 0.0)
+
+        elif not self._labels_hash and not self.CONNECTION_POOL.exists(self._key_name):
+            self.CONNECTION_POOL.incrbyfloat(self._key_name, 0.0)
+
+        self.CONNECTION_POOL.expire(self._key_name, self.EXPIRE_KEY_TIME)
+
+    @classmethod
+    def _generate_samples(cls, registry: "Registry") -> Dict["Collector", List["Sample"]]:
+        assert cls.CONNECTION_POOL is not None
+
+        # collect samples that are not yet stored with the value
+        samples_dict = {}
+        pipeline = cls.CONNECTION_POOL.pipeline()
+        for collector in registry.collect():
+            samples_list: List[Sample] = []
+            samples_dict[collector] = samples_list
+
+            key_name = collector.name
+
+            if collector._required_labels:
+                # hash
+                if collector.type_ in (MetricType.COUNTER, MetricType.GAUGE):
+                    pipeline.expire(key_name, cls.EXPIRE_KEY_TIME)
+                    pipeline.hgetall(key_name)
+                elif collector.type_ == MetricType.SUMMARY:
+                    for suffix in ("count", "sum"):
+                        key_with_suffix = f"{key_name}:{suffix}"
+                        pipeline.expire(key_with_suffix, cls.EXPIRE_KEY_TIME)
+                        pipeline.hgetall(key_with_suffix)
+                elif collector.type_ == MetricType.HISTOGRAM:
+                    for suffix in collector._metric._upper_bounds[:-1] + [
+                        "+Inf",
+                        "count",
+                        "sum",
+                    ]:
+                        key_with_suffix = f"{key_name}:{suffix}"
+                        pipeline.expire(key_with_suffix, cls.EXPIRE_KEY_TIME)
+                        pipeline.hgetall(key_with_suffix)
+            else:
+                # not hash
+                if collector.type_ in (MetricType.COUNTER, MetricType.GAUGE):
+                    pipeline.expire(key_name, cls.EXPIRE_KEY_TIME)
+                    pipeline.get(key_name)
+                elif collector.type_ == MetricType.SUMMARY:
+                    for suffix in ("count", "sum"):
+                        key_with_suffix = f"{key_name}:{suffix}"
+                        pipeline.expire(key_with_suffix, cls.EXPIRE_KEY_TIME)
+                        pipeline.get(key_with_suffix)
+                elif collector.type_ == MetricType.HISTOGRAM:
+                    for suffix in collector._metric._upper_bounds[:-1] + [
+                        "+Inf",
+                        "count",
+                        "sum",
+                    ]:
+                        key_with_suffix = f"{key_name}:{suffix}"
+                        pipeline.expire(key_with_suffix, cls.EXPIRE_KEY_TIME)
+                        pipeline.get(key_with_suffix)
+
+        pipeline_data = pipeline.execute()
+
+        values = [
+            0 if item is None else item for item in pipeline_data if item not in (True, False)
+        ]
+
+        # build samples
+        for collector, samples_list in samples_dict.items():
+            if collector._required_labels:
+                # hash
+                if collector.type_ in (MetricType.COUNTER, MetricType.GAUGE):
+                    values_dict = values[0]
+                    values = values[1:]
+                    for labels, value in values_dict.items():
+                        samples_list.append(Sample("", json.loads(labels), float(value)))
+                elif collector.type_ == MetricType.SUMMARY:
+                    count_dict = values[0]
+                    sum_dict = values[1]
+                    values = values[2:]
+                    ordered_samples = defaultdict(list)
+                    for labels_str, value in count_dict.items():
+                        ordered_samples[labels_str].append(
+                            Sample("_count", json.loads(labels_str), float(value))
+                        )
+
+                    for labels_str, value in sum_dict.items():
+                        ordered_samples[labels_str].append(
+                            Sample("_sum", json.loads(labels_str), float(value))
+                        )
+
+                    for ordered_sample_list in ordered_samples.values():
+                        samples_list.extend(ordered_sample_list)
+
+                elif collector.type_ == MetricType.HISTOGRAM:
+                    index = 0
+                    suffixes = collector._metric._upper_bounds[:-1] + ["+Inf", "count", "sum"]
+                    # for exposition we want to maintain order based on increasing le values
+                    ordered_samples = defaultdict(list)
+                    for suffix in suffixes:
+                        values_dict = values[index]
+                        index += 1
+
+                        if isinstance(suffix, (int, float)) or suffix == "+Inf":
+                            for labels_str, value in values_dict.items():
+                                labels = json.loads(labels_str)
+                                labels["le"] = str(suffix)
+                                ordered_samples[labels_str].append(
+                                    Sample("_bucket", labels, float(value))
+                                )
+                        elif suffix == "count":
+                            for labels_str, value in values_dict.items():
+                                ordered_samples[labels_str].append(
+                                    Sample("_count", json.loads(labels_str), float(value))
+                                )
+                        elif suffix == "sum":
+                            for labels_str, value in values_dict.items():
+                                ordered_samples[labels_str].append(
+                                    Sample("_sum", json.loads(labels_str), float(value))
+                                )
+
+                    for ordered_sample_list in ordered_samples.values():
+                        samples_list.extend(ordered_sample_list)
+
+                    values = values[len(suffixes) :]
+            else:
+                if collector.type_ in (MetricType.COUNTER, MetricType.GAUGE):
+                    value = values[0]
+                    values = values[1:]
+                    samples_list.append(Sample("", None, float(value)))
+                elif collector.type_ == MetricType.SUMMARY:
+                    count_value = values[0]
+                    sum_value = values[1]
+                    values = values[2:]
+                    samples_list.append(Sample("_count", None, float(count_value)))
+                    samples_list.append(Sample("_sum", None, float(sum_value)))
+                elif collector.type_ == MetricType.HISTOGRAM:
+                    index = 0
+                    suffixes = collector._metric._upper_bounds[:-1] + ["+Inf", "count", "sum"]
+                    for suffix in suffixes:
+                        value = values[index]
+                        index += 1
+
+                        if isinstance(suffix, (int, float)) or suffix == "+Inf":
+                            labels = {"le": str(suffix)}
+                            samples_list.append(Sample("_bucket", labels, float(value)))
+                        elif suffix == "count":
+                            samples_list.append(Sample("_count", None, float(value)))
+                        elif suffix == "sum":
+                            samples_list.append(Sample("_sum", None, float(value)))
+
+                    values = values[len(suffixes) :]
+
+        return samples_dict
+
+    def inc(self, value: float) -> None:
+        assert self.CONNECTION_POOL is not None
+        if self._labels_hash:
+            self.CONNECTION_POOL.hincrbyfloat(self._key_name, self._labels_hash, value)
+        else:
+            self.CONNECTION_POOL.incrbyfloat(self._key_name, value)
+
+        self.CONNECTION_POOL.expire(self._key_name, self.EXPIRE_KEY_TIME)
+
+    def dec(self, value: float) -> None:
+        assert self.CONNECTION_POOL is not None
+        if self._labels_hash:
+            self.CONNECTION_POOL.hincrbyfloat(self._key_name, self._labels_hash, -value)
+        else:
+            self.CONNECTION_POOL.incrbyfloat(self._key_name, -value)
+
+        self.CONNECTION_POOL.expire(self._key_name, self.EXPIRE_KEY_TIME)
+
+    def set(self, value: float) -> None:
+        assert self.CONNECTION_POOL is not None
+        if self._labels_hash:
+            self.CONNECTION_POOL.hset(self._key_name, self._labels_hash, value)
+        else:
+            self.CONNECTION_POOL.set(self._key_name, value)
+
+        self.CONNECTION_POOL.expire(self._key_name, self.EXPIRE_KEY_TIME)
+
+    def get(self) -> float:
+        """
+        This is not used directly, useful for tests and possibly debugging so leaving it in but
+        it's not used outside of these cases.
+        """
+        assert self.CONNECTION_POOL is not None
+
+        if self._labels_hash:
+            value = self.CONNECTION_POOL.hget(self._key_name, self._labels_hash)
+        else:
+            value = self.CONNECTION_POOL.get(self._key_name)
+
+        self.CONNECTION_POOL.expire(self._key_name, self.EXPIRE_KEY_TIME)
+
+        return float(value) if value else 0.0

--- a/tests/backends/test_background_redis.py
+++ b/tests/backends/test_background_redis.py
@@ -1,0 +1,536 @@
+from concurrent.futures import ProcessPoolExecutor
+from importlib.util import find_spec
+from time import sleep
+from unittest import mock
+
+import pytest
+
+from pytheus.backends.base import SingleProcessBackend, load_backend
+from pytheus.backends.background_redis import MultiProcessBackgroundRedisBackend
+from pytheus.exposition import generate_metrics
+from pytheus.metrics import Counter, Gauge, Histogram, Sample, Summary
+from pytheus.registry import CollectorRegistry
+
+if not find_spec("redis"):
+    pytest.skip("skipping redis tests as the module was not found", allow_module_level=True)
+
+
+load_backend(MultiProcessBackgroundRedisBackend)
+pool = MultiProcessBackgroundRedisBackend.CONNECTION_POOL
+
+
+# when running a single test might not be picking up the backend so
+# we enforce it
+@pytest.fixture(autouse=True)
+def load_backgroun_redis_backend():
+    load_backend(MultiProcessBackgroundRedisBackend)
+
+
+# automatically clear the cache after every test function
+@pytest.fixture(autouse=True)
+def clear_background_redis():
+    pool.flushall()
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        MultiProcessBackgroundRedisBackend({}, Counter("name", "desc", registry=None)),
+        MultiProcessBackgroundRedisBackend(
+            {},
+            Counter(
+                "name_labels",
+                "desc",
+                required_labels=["bob"],
+                default_labels={"bob": "cat"},
+                registry=None,
+            ),
+        ),
+    ],
+)
+class TestMultiProcessBackgroundRedisBackend:
+    @pytest.fixture(autouse=True)
+    def _init_key(self, backend):
+        backend._init_key()
+
+    def test_get(self, backend):
+        assert backend.get() == 0.0
+
+    def test_inc(self, backend):
+        backend.inc(1.0)
+        sleep(0.01)
+        assert backend.get() == 1.0
+
+    def test_dec(self, backend):
+        backend.dec(1.0)
+        sleep(0.01)
+        assert backend.get() == -1.0
+
+    def test_set(self, backend):
+        backend.set(3.0)
+        sleep(0.01)
+        assert backend.get() == 3.0
+
+    def test_get_handles_remote_key_deletion(self, backend):
+        pool.flushall()
+        sleep(0.01)
+        assert backend.get() == 0.0
+
+
+def test_create_backend():
+    counter = Counter("name", "desc")
+    backend = MultiProcessBackgroundRedisBackend({}, counter)
+
+    assert backend._key_name == counter.name
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash is None
+    assert pool.exists(backend._key_name)
+
+
+def test_create_backend_with_prefix():
+    counter = Counter("name", "desc")
+    backend = MultiProcessBackgroundRedisBackend({"key_prefix": "test"}, counter)
+
+    assert backend._key_name == f"test-{counter.name}"
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash is None
+    assert pool.exists(backend._key_name)
+
+
+def test_create_backend_labeled():
+    counter = Counter("name", "desc", required_labels=["bob"])
+    counter = counter.labels({"bob": "cat"})
+    backend = MultiProcessBackgroundRedisBackend({}, counter)
+
+    assert backend._key_name == counter.name
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash == '{"bob": "cat"}'
+    assert pool.hexists(backend._key_name, backend._labels_hash)
+
+
+def test_create_backend_labeled_with_prefix():
+    counter = Counter("name", "desc", required_labels=["bob"])
+    counter = counter.labels({"bob": "cat"})
+    backend = MultiProcessBackgroundRedisBackend({"key_prefix": "test"}, counter)
+
+    assert backend._key_name == f"test-{counter.name}"
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash == '{"bob": "cat"}'
+    assert pool.hexists(backend._key_name, backend._labels_hash)
+
+
+def test_create_backend_labeled_with_default():
+    counter = Counter("name", "desc", required_labels=["bob"], default_labels={"bob": "cat"})
+    backend = MultiProcessBackgroundRedisBackend({}, counter)
+
+    assert backend._key_name == counter.name
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash == '{"bob": "cat"}'
+    assert pool.hexists(backend._key_name, backend._labels_hash)
+
+
+def test_create_backend_labeled_with_default_mixed():
+    counter = Counter(
+        "name", "desc", required_labels=["bob", "bobby"], default_labels={"bob": "cat"}
+    )
+    counter = counter.labels({"bobby": "fish"})
+    backend = MultiProcessBackgroundRedisBackend({}, counter)
+
+    assert backend._key_name == counter.name
+    assert backend._histogram_bucket is None
+    assert backend._labels_hash == '{"bob": "cat", "bobby": "fish"}'
+    assert pool.hexists(backend._key_name, backend._labels_hash)
+
+
+def test_create_backend_with_histogram_bucket():
+    histogram_bucket = "+Inf"
+    counter = Counter("name", "desc")
+    backend = MultiProcessBackgroundRedisBackend({}, counter, histogram_bucket=histogram_bucket)
+
+    assert backend._key_name == f"{counter.name}:{histogram_bucket}"
+    assert backend._histogram_bucket == histogram_bucket
+    assert backend._labels_hash is None
+    assert pool.exists(f"{counter.name}:{histogram_bucket}")
+
+
+@mock.patch.object(MultiProcessBackgroundRedisBackend, "_initialize")
+def test_create_histogram_with_prefix(_mock_initialize):
+    load_backend(MultiProcessBackgroundRedisBackend, {"key_prefix": "test"})
+
+    Histogram("histogram", "description")
+
+    histogram_keys = pool.keys()
+    assert len(histogram_keys) == 14
+    for key in histogram_keys:
+        assert key.startswith("test-")
+
+
+# multiple metrics with same name tests, especially when sharing redis as a backend
+
+
+def test_multiple_metrics_with_same_name_with_redis_overlap():
+    """
+    If sharing the same database, single value metrics will be overlapping.
+    """
+    first_collector = CollectorRegistry()
+    second_collector = CollectorRegistry()
+
+    counter_a = Counter("shared_name", "description", registry=first_collector)
+    counter_b = Counter("shared_name", "description", registry=second_collector)
+
+    counter_a.inc()
+    sleep(0.01)
+
+    assert counter_a._metric_value_backend.get() == 1.0
+    assert counter_b._metric_value_backend.get() == 1.0
+
+
+def test_multiple_metrics_with_same_name_labeled_with_redis_do_not_overlap():
+    """
+    Even while sharing the same database, labeled metrics won't be returned from collectors not
+    having the specific child instance.
+    """
+    first_collector = CollectorRegistry()
+    second_collector = CollectorRegistry()
+
+    counter_a = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=first_collector
+    )
+    counter_b = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=second_collector
+    )
+
+    counter_a.labels({"bob": "cat"})
+    counter_b.labels({"bob": "bobby"})
+
+    first_collector_metrics_count = len(list(first_collector.collect().__next__().collect()))
+    second_collector_metrics_count = len(list(second_collector.collect().__next__().collect()))
+
+    assert first_collector_metrics_count == 1
+    assert second_collector_metrics_count == 1
+
+
+def test_multiple_metrics_with_same_name_labeled_with_redis_do_overlap_on_shared_child():
+    """
+    If sharing the same database, labeled metrics will be returned from collectors if having the
+    same child instance.
+    """
+    first_collector = CollectorRegistry()
+    second_collector = CollectorRegistry()
+
+    counter_a = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=first_collector
+    )
+    counter_b = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=second_collector
+    )
+
+    counter_a.labels({"bob": "cat"})
+    counter_b.labels({"bob": "bobby"})
+    counter_b.labels({"bob": "cat"}).inc()
+    sleep(0.01)
+
+    first_collector_metrics_count = len(list(first_collector.collect().__next__().collect()))
+    second_collector_metrics_count = len(list(second_collector.collect().__next__().collect()))
+
+    assert first_collector_metrics_count == 1
+    assert second_collector_metrics_count == 2
+    assert counter_a.labels({"bob": "cat"})._metric_value_backend.get() == 1
+    assert counter_b.labels({"bob": "cat"})._metric_value_backend.get() == 1
+
+
+def test_multiple_metrics_with_same_name_with_redis_key_prefix():
+    first_collector = CollectorRegistry()
+    second_collector = CollectorRegistry()
+
+    load_backend(MultiProcessBackgroundRedisBackend, {"key_prefix": "a"})
+    counter_a = Counter("shared_name", "description", registry=first_collector)
+    load_backend(MultiProcessBackgroundRedisBackend, {"key_prefix": "b"})
+    counter_b = Counter("shared_name", "description", registry=second_collector)
+
+    counter_a.inc()
+    sleep(0.01)
+
+    assert counter_a._metric_value_backend.get() == 1.0
+    assert counter_b._metric_value_backend.get() == 0
+
+
+def test_multiple_metrics_with_same_name_labeled_with_redis_key_name_dont_overlap_on_shared_child():
+    first_collector = CollectorRegistry()
+    second_collector = CollectorRegistry()
+
+    load_backend(MultiProcessBackgroundRedisBackend, {"key_prefix": "a"})
+    counter_a = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=first_collector
+    )
+    counter_a.labels({"bob": "cat"})
+    load_backend(MultiProcessBackgroundRedisBackend, {"key_prefix": "b"})
+    counter_b = Counter(
+        "shared_name", "description", required_labels=["bob"], registry=second_collector
+    )
+
+    counter_b.labels({"bob": "bobby"})
+    counter_b.labels({"bob": "cat"}).inc()
+    sleep(0.01)
+
+    first_collector_metrics_count = len(list(first_collector.collect().__next__().collect()))
+    second_collector_metrics_count = len(list(second_collector.collect().__next__().collect()))
+
+    assert first_collector_metrics_count == 1
+    assert second_collector_metrics_count == 2
+    assert counter_a.labels({"bob": "cat"})._metric_value_backend.get() == 0
+    assert counter_b.labels({"bob": "cat"})._metric_value_backend.get() == 1
+
+
+def test_generate_samples():
+    registry = CollectorRegistry()
+    counter = Counter("name", "desc", registry=registry)
+    histogram = Histogram("histogram", "desc", registry=registry)
+    samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+    assert len(samples[counter._collector]) == 1
+    assert len(samples[histogram._collector]) == 14
+
+
+def test_generate_samples_with_labels():
+    load_backend(MultiProcessBackgroundRedisBackend)
+    registry = CollectorRegistry()
+    counter = Counter(
+        "name", "desc", required_labels=["bob"], default_labels={"bob": "c"}, registry=registry
+    )
+    counter.labels({"bob": "a"})
+    counter.labels({"bob": "b"})
+    samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+    assert len(samples[counter._collector]) == 3
+
+
+def _run_multiprocess(extra_label):
+    load_backend(
+        backend_class=MultiProcessBackgroundRedisBackend,
+        # backend_config={"host": "127.0.0.1", "port": 6379},
+    )
+    registry = CollectorRegistry()
+    counter = Counter("name_multiple", "desc", required_labels=["bob"], registry=registry)
+    counter.labels(bob="cat")
+    gauge = Gauge("gauge_multiple", "desc", required_labels=["bob"], registry=registry)
+    summary = Summary("summary_multiple", "desc", required_labels=["bob"], registry=registry)
+    histogram = Histogram("histogram_multiple", "desc", required_labels=["bob"], registry=registry)
+    if extra_label:
+        counter.labels(bob="created_only_on_one").inc(3.0)
+        gauge.labels(bob="observable_only_on_one").inc(2.7)
+        summary.labels(bob="observable_only_on_one").observe(2.7)
+        histogram.labels(bob="observable_only_on_one").observe(2.7)
+    sleep(0.01)
+    return generate_metrics(registry)
+
+
+def test_multiple_return_all_metrics_entries():
+    """
+    Test that if a metric labeled child is created on a process, it will be retrieved even if the
+    instance doesn't exist on a different process.
+    """
+    with ProcessPoolExecutor() as executor:
+        first_result = executor.submit(_run_multiprocess, extra_label=True)
+        first_result = first_result.result()
+        second_result = executor.submit(_run_multiprocess, extra_label=False)
+        second_result = second_result.result()
+
+        assert first_result == second_result
+
+
+class TestGenerateSamples:
+    def test_counter(self):
+        registry = CollectorRegistry()
+        counter = Counter("counter", "desc", registry=registry)
+        expected_samples = {counter._collector: [Sample("", None, 0.0)]}
+
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_counter_labeled(self):
+        registry = CollectorRegistry()
+        counter = Counter("counter", "desc", required_labels=["bob"], registry=registry)
+        counter.labels(bob="cat").inc(2.7)
+        expected_samples = {counter._collector: [Sample("", {"bob": "cat"}, 2.7)]}
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_gauge(self):
+        registry = CollectorRegistry()
+        gauge = Gauge("gauge", "desc", registry=registry)
+        expected_samples = {gauge._collector: [Sample("", None, 0.0)]}
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_gauge_labeled(self):
+        registry = CollectorRegistry()
+        gauge = Gauge("gauge", "desc", required_labels=["bob"], registry=registry)
+        gauge.labels(bob="cat").inc(2.7)
+        expected_samples = {gauge._collector: [Sample("", {"bob": "cat"}, 2.7)]}
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_metric_labeled_multiple(self):
+        registry = CollectorRegistry()
+        counter_labeled = Counter(
+            "counter_labeled", "desc", required_labels=["bob"], registry=registry
+        )
+        counter_labeled.labels(bob="cat").inc(2.7)
+        gauge = Gauge("gauge", "desc", required_labels=["bob"], registry=registry)
+        gauge.labels(bob="gage").inc(3.0)
+        gauge.labels(bob="blob").inc(3.2)
+        counter = Counter("counter", "desc", registry=registry)
+        expected_samples = {
+            counter_labeled._collector: [Sample("", {"bob": "cat"}, 2.7)],
+            gauge._collector: [Sample("", {"bob": "gage"}, 3.0), Sample("", {"bob": "blob"}, 3.2)],
+            counter._collector: [Sample("", None, 0.0)],
+        }
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_summary(self):
+        registry = CollectorRegistry()
+        summary = Summary("summary", "desc", registry=registry)
+        expected_samples = {
+            summary._collector: [Sample("_count", None, 0.0), Sample("_sum", None, 0.0)],
+        }
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_summary_labeled(self):
+        registry = CollectorRegistry()
+        summary = Summary(
+            "summary",
+            "desc",
+            registry=registry,
+            required_labels=["bob"],
+            default_labels={"bob": "cat"},
+        )
+        summary.observe(7)
+        expected_samples = {
+            summary._collector: [
+                Sample("_count", {"bob": "cat"}, 1.0),
+                Sample("_sum", {"bob": "cat"}, 7.0),
+            ],
+        }
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_histogram(self):
+        registry = CollectorRegistry()
+        histogram = Histogram("histogram", "desc", buckets=[1, 2, 3], registry=registry)
+        histogram.observe(2.7)
+        expected_samples = {
+            histogram._collector: [
+                Sample("_bucket", {"le": "1"}, 0.0),
+                Sample("_bucket", {"le": "2"}, 0.0),
+                Sample("_bucket", {"le": "3"}, 1.0),
+                Sample("_bucket", {"le": "+Inf"}, 1.0),
+                Sample("_count", None, 1.0),
+                Sample("_sum", None, 2.7),
+            ],
+        }
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_histogram_labeled(self):
+        registry = CollectorRegistry()
+        histogram = Histogram(
+            "histogram", "desc", buckets=[1, 2, 3], required_labels=["bob"], registry=registry
+        )
+        histogram.labels(bob="cat").observe(2.7)
+        expected_samples = {
+            histogram._collector: [
+                Sample("_bucket", {"bob": "cat", "le": "1"}, 0.0),
+                Sample("_bucket", {"bob": "cat", "le": "2"}, 0.0),
+                Sample("_bucket", {"bob": "cat", "le": "3"}, 1.0),
+                Sample("_bucket", {"bob": "cat", "le": "+Inf"}, 1.0),
+                Sample("_count", {"bob": "cat"}, 1.0),
+                Sample("_sum", {"bob": "cat"}, 2.7),
+            ],
+        }
+
+        sleep(0.01)
+        samples = MultiProcessBackgroundRedisBackend._generate_samples(registry)
+        assert samples == expected_samples
+
+    def test_labeled_histogram_is_ordered(self):
+        registry = CollectorRegistry()
+        histogram = Histogram(
+            "histogram", "desc", buckets=[1, 2, 3], required_labels=["bob"], registry=registry
+        )
+        histogram.labels(bob="cat")
+        histogram.labels(bob="bobby")
+        metrics_output = generate_metrics(registry)
+        assert metrics_output == (
+            "# HELP histogram desc\n"
+            "# TYPE histogram histogram\n"
+            'histogram_bucket{bob="cat",le="1"} 0.0\n'
+            'histogram_bucket{bob="cat",le="2"} 0.0\n'
+            'histogram_bucket{bob="cat",le="3"} 0.0\n'
+            'histogram_bucket{bob="cat",le="+Inf"} 0.0\n'
+            'histogram_count{bob="cat"} 0.0\n'
+            'histogram_sum{bob="cat"} 0.0\n'
+            'histogram_bucket{bob="bobby",le="1"} 0.0\n'
+            'histogram_bucket{bob="bobby",le="2"} 0.0\n'
+            'histogram_bucket{bob="bobby",le="3"} 0.0\n'
+            'histogram_bucket{bob="bobby",le="+Inf"} 0.0\n'
+            'histogram_count{bob="bobby"} 0.0\n'
+            'histogram_sum{bob="bobby"} 0.0\n'
+        )
+
+    def test_labeled_summary_is_ordered(self):
+        registry = CollectorRegistry()
+        summary = Summary("summary", "desc", required_labels=["bob"], registry=registry)
+        summary.labels(bob="cat")
+        summary.labels(bob="bobby")
+        metrics_output = generate_metrics(registry)
+        assert metrics_output == (
+            "# HELP summary desc\n"
+            "# TYPE summary summary\n"
+            'summary_count{bob="cat"} 0.0\n'
+            'summary_sum{bob="cat"} 0.0\n'
+            'summary_count{bob="bobby"} 0.0\n'
+            'summary_sum{bob="bobby"} 0.0\n'
+        )
+
+    def test_labeled_not_observable(self):
+        registry = CollectorRegistry()
+        Counter("counter", "desc", required_labels=["bob"], registry=registry)
+        Gauge("gauge", "desc", required_labels=["bob"], registry=registry)
+        Summary("summary", "desc", required_labels=["bob"], registry=registry)
+        Histogram("histogram", "desc", required_labels=["bob"], registry=registry)
+        metrics_output = generate_metrics(registry)
+        assert metrics_output == (
+            "# HELP counter desc\n"
+            "# TYPE counter counter\n"
+            "# HELP gauge desc\n"
+            "# TYPE gauge gauge\n"
+            "# HELP summary desc\n"
+            "# TYPE summary summary\n"
+            "# HELP histogram desc\n"
+            "# TYPE histogram histogram\n"
+        )
+
+
+def test_set_expire_key_time():
+    load_backend(MultiProcessBackgroundRedisBackend, {"expire_key_time": 300})
+
+    assert MultiProcessBackgroundRedisBackend.EXPIRE_KEY_TIME == 300
+
+
+# reset to the SingleProcessBackend for other tests
+load_backend(SingleProcessBackend)


### PR DESCRIPTION
*Running those tests break the pipeline as the worker thread is not correctly shut down, and so it is stuck.* But they all pass locally, which is the purpose of this PoC I guess.

Possible/mandatory improvements:
- Graceful shutdown of the worker thread (would fix the pipeline)
- Use async redis in the worker thread to handle multiple operations concurrently
- Handle failure on ‘inc’ / ‘dec’ operations
- User-set limits for queue length and warning mechanisms for when the queue is reaching certain thresholds (send a log every x minutes when warning threshold or limit is reached)
- Different datastruct than a queue to detect when multiple operations target the same key, aggregate inc/dec locally to only send one “batch” operation to Redis